### PR TITLE
Gracefully Handle Rejected Reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ $ poetry run poe {format,check,test,all}
 $ poetry run groundtruth --help
 ```
 
+**CAVEATS:**
+- This program requires Auto Review to be enabled for the workflow/submissions.
+- This program only considers the first ground truth/prediction value for each field.
+
 ## Analysis Process
 
 `groundtruth` is used to aid the ground truth analysis process for a model or workflow.

--- a/groundtruth/extractions.py
+++ b/groundtruth/extractions.py
@@ -97,7 +97,8 @@ def all_fields_in_results(
             model_dict = document_dict["results"][model]
             post_reviews = model_dict["post_reviews"]
             auto_review = post_reviews[-1]
-        except (IndexError, KeyError, TypeError):
+            assert auto_review is not None  # Rejected in review
+        except (AssertionError, IndexError, KeyError, TypeError):
             logger.warning(
                 f"Result '{result_file_name}' does not contain an auto review for "
                 f"model '{model}'."
@@ -106,7 +107,8 @@ def all_fields_in_results(
 
         try:
             hitl_review = post_reviews[-2]
-        except IndexError:
+            assert hitl_review is not None  # Rejected in review
+        except (AssertionError, IndexError):
             logger.warning(
                 f"Result '{result_file_name}' does not contain a HITL review for "
                 f"model '{model}'."
@@ -163,7 +165,8 @@ def extractions_for_result(
         model_dict = document_dict["results"][model]
         post_reviews = model_dict["post_reviews"]
         auto_review = post_reviews[-1]
-    except (IndexError, KeyError, TypeError):
+        assert auto_review is not None  # Rejected in review
+    except (AssertionError, IndexError, KeyError, TypeError):
         logger.warning(
             f"Result '{result_file_name}' does not contain an auto review for model "
             f"'{model}'. Skipping."
@@ -172,7 +175,8 @@ def extractions_for_result(
 
     try:
         hitl_review = post_reviews[-2]
-    except IndexError:
+        assert hitl_review is not None  # Rejected in review
+    except (AssertionError, IndexError):
         logger.warning(
             f"Result '{result_file_name}' does not contain a HITL review for model "
             f"'{model}'. Missing ground truth."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "groundtruth"
-version = "1.1.0"
+version = "1.1.1"
 description = "Ground Truth Analysis Tooling"
 authors = [
     "Anna Liu <anna.liu@indicodata.ai>",


### PR DESCRIPTION
When a review is rejected, the `final` and `post_reviews` predictions lists are set to `null`. This PR accommodates that behavior to prevent the program from crashing when extracting ground truths and predictions.